### PR TITLE
install the virtual environment in a location that wont be overwritte…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,17 @@ FROM --platform=linux/amd64 nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04
 ENV TZ=US \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y git gcc g++ nano parallel curl dvipng wget python3-dev && apt-get clean
+RUN apt-get update && apt-get install -y \
+    git gcc g++ nano parallel curl dvipng wget \
+    python3-dev python-is-python3 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV CONTAINER_USER=uvser
+ENV CONTAINER_USER=user
 RUN useradd -m -s /bin/bash ${CONTAINER_USER} && \
     echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 USER ${CONTAINER_USER}
-WORKDIR /workspace
+WORKDIR /home/${CONTAINER_USER}
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/home/${CONTAINER_USER}/.local/bin:${PATH}"
@@ -19,11 +22,12 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 
 COPY --chown=${CONTAINER_USER}:${CONTAINER_USER} ./uv.lock ./uv.lock
 COPY --chown=${CONTAINER_USER}:${CONTAINER_USER} ./pyproject.toml ./pyproject.toml
-RUN uv venv --seed .venv && \
-    uv sync
+
+RUN uv venv .venv && uv sync --no-install-project
 
 ENV VIRTUAL_ENV="/home/${CONTAINER_USER}/.venv"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN echo 'source /workspace/.venv/bin/activate' >> /home/${CONTAINER_USER}/.bashrc
+
+WORKDIR /workspace
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
…n once the container is e.g. used as a dev container

remove unnecessary echo into .bashrc

do not install project modules as the code is not copied into the container. if someone want so use project internal modules, it has to be solves in a differnent way